### PR TITLE
Improve tests and prepend module names with "T"

### DIFF
--- a/src/Elm.elm
+++ b/src/Elm.elm
@@ -19,7 +19,7 @@ fromText : String -> Dict Text.Path Text.Module -> List File
 fromText rootModule =
     let
         preparePath path =
-            List.map String.toCamelCaseUpper (rootModule :: path)
+            List.map (String.toCamelCaseUpper >> adaptName 'T') (rootModule :: path)
     in
     Dict.foldl (\path module_ files -> makeFile (preparePath path) module_ :: files) []
 

--- a/tests/ElmTests.elm
+++ b/tests/ElmTests.elm
@@ -9,9 +9,9 @@ import Test exposing (..)
 import Text exposing (Text(..))
 
 
-static : Test
-static =
-    describe "static text"
+tests : Test
+tests =
+    describe "Elm.fromText"
         [ test "it works with the most simple static case" <|
             \_ ->
                 singleTextModule "bar"
@@ -56,21 +56,8 @@ static =
         ]
 
 
-expectValidFile : Elm.File -> List Elm.File -> Expectation
-expectValidFile expectedFile actualFiles =
-    case Elm.DSLParser.parse expectedFile.content of
-        Ok _ ->
-            Expect.equal [ expectedFile ] actualFiles
 
-        Err _ ->
-            let
-                error =
-                    "I couldn't parse this expected Elm file:\n\n"
-                        ++ expectedFile.content
-                        ++ "\n\nHere's what the code you tested, returned:\n\n"
-                        ++ Debug.toString actualFiles
-            in
-            Expect.fail error
+-- EXPECTED FILES
 
 
 simpleStaticFile : Elm.File
@@ -146,108 +133,22 @@ multipleFiles =
     ]
 
 
-suite : Test
-suite =
-    test "Text.fromJson" <|
-        \_ ->
-            Dict.fromList
-                [ ( []
-                  , Dict.fromList
-                        [ ( "foo", [ Text.Static "bar" ] )
-                        , ( "1bad__key", [ Text.Static "with", Text.Parameter "1bad_param" ] )
-                        , ( "repeated_param", [ Text.Parameter "foo", Text.Static ", I repeat, ", Text.Parameter "foo" ] )
-                        ]
-                  )
-                , ( [ "temporality", "date_formats" ]
-                  , Dict.fromList
-                        [ ( "year difference"
-                          , [ Text.Static "The difference between "
-                            , Text.Parameter "first_year"
-                            , Text.Static " and "
-                            , Text.Parameter "second_year"
-                            , Text.Static " is "
-                            , Text.Parameter "year_difference"
-                            , Text.Static "."
-                            ]
-                          )
-                        ]
-                  )
-                , ( [ "temporality" ]
-                  , Dict.fromList
-                        [ ( "current_date_and_time"
-                          , [ Text.Static "The date is "
-                            , Text.Parameter "date"
-                            , Text.Static " and the time is "
-                            , Text.Parameter "time"
-                            ]
-                          )
-                        , ( "current_time"
-                          , [ Text.Static "The time is "
-                            , Text.Parameter "time"
-                            , Text.Static " now."
-                            ]
-                          )
-                        ]
-                  )
-                ]
-                |> Elm.fromText "Text"
-                |> Expect.equal
-                    [ { content = module1, path = [ "Text", "Temporality", "DateFormats" ] }
-                    , { content = module2, path = [ "Text", "Temporality" ] }
-                    , { content = module3, path = [ "Text" ] }
-                    ]
+
+-- HELPERS
 
 
-module1 : String
-module1 =
-    """module Text.Temporality.DateFormats exposing (..)
+expectValidFile : Elm.File -> List Elm.File -> Expectation
+expectValidFile expectedFile actualFiles =
+    case Elm.DSLParser.parse expectedFile.content of
+        Ok _ ->
+            Expect.equal [ expectedFile ] actualFiles
 
-
-yearDifference : (String -> a) -> { firstYear : a, secondYear : a, yearDifference : a } -> List a
-yearDifference fromString parameters =
-    [ fromString "The difference between "
-    , parameters.firstYear
-    , fromString " and "
-    , parameters.secondYear
-    , fromString " is "
-    , parameters.yearDifference
-    , fromString "."
-    ]
-"""
-
-
-module2 : String
-module2 =
-    """module Text.Temporality exposing (..)
-
-
-currentDateAndTime : (String -> a) -> { date : a, time : a } -> List a
-currentDateAndTime fromString parameters =
-    [ fromString "The date is ", parameters.date, fromString " and the time is ", parameters.time ]
-
-
-currentTime : (String -> a) -> { time : a } -> List a
-currentTime fromString parameters =
-    [ fromString "The time is ", parameters.time, fromString " now." ]
-"""
-
-
-module3 : String
-module3 =
-    """module Text exposing (..)
-
-
-t1badKey : (String -> a) -> { p1badParam : a } -> List a
-t1badKey fromString parameters =
-    [ fromString "with", parameters.p1badParam ]
-
-
-foo : String
-foo =
-    "bar"
-
-
-repeatedParam : (String -> a) -> { foo : a } -> List a
-repeatedParam fromString parameters =
-    [ parameters.foo, fromString ", I repeat, ", parameters.foo ]
-"""
+        Err _ ->
+            let
+                error =
+                    "I couldn't parse this expected Elm file:\n\n"
+                        ++ expectedFile.content
+                        ++ "\n\nHere's what the code you tested, returned:\n\n"
+                        ++ Debug.toString actualFiles
+            in
+            Expect.fail error

--- a/tests/ElmTests.elm
+++ b/tests/ElmTests.elm
@@ -43,6 +43,16 @@ static =
                     ]
                     |> Elm.fromText "123"
                     |> expectValidFile prefixedFile
+        , test "it returns multiple files" <|
+            \_ ->
+                Dict.fromList
+                    [ ( [], Dict.fromList [ ( "a", [ Text.Static "a" ] ) ] )
+                    , ( [ "b" ], Dict.fromList [ ( "b", [ Text.Static "b" ] ) ] )
+                    , ( [ "b", "c" ], Dict.fromList [ ( "c", [ Text.Static "c" ] ) ] )
+                    , ( [ "b", "c", "d" ], Dict.fromList [ ( "d", [ Text.Static "d" ] ) ] )
+                    ]
+                    |> Elm.fromText "a"
+                    |> Expect.equalLists multipleFiles
         ]
 
 
@@ -117,6 +127,23 @@ t456 fromString parameters =
     [ fromString "im left alone", parameters.p789 ]
 """
     }
+
+
+multipleFiles : List Elm.File
+multipleFiles =
+    [ { content = "module A.B.C.D exposing (..)\n\n\nd : String\nd =\n    \"d\"\n"
+      , path = [ "A", "B", "C", "D" ]
+      }
+    , { content = "module A.B.C exposing (..)\n\n\nc : String\nc =\n    \"c\"\n"
+      , path = [ "A", "B", "C" ]
+      }
+    , { content = "module A.B exposing (..)\n\n\nb : String\nb =\n    \"b\"\n"
+      , path = [ "A", "B" ]
+      }
+    , { content = "module A exposing (..)\n\n\na : String\na =\n    \"a\"\n"
+      , path = [ "A" ]
+      }
+    ]
 
 
 suite : Test

--- a/tests/ElmTests.elm
+++ b/tests/ElmTests.elm
@@ -46,10 +46,10 @@ tests =
         , test "it returns multiple files" <|
             \_ ->
                 Dict.fromList
-                    [ ( [], Dict.fromList [ ( "a", [ Text.Static "a" ] ) ] )
-                    , ( [ "b" ], Dict.fromList [ ( "b", [ Text.Static "b" ] ) ] )
-                    , ( [ "b", "c" ], Dict.fromList [ ( "c", [ Text.Static "c" ] ) ] )
-                    , ( [ "b", "c", "d" ], Dict.fromList [ ( "d", [ Text.Static "d" ] ) ] )
+                    [ ( [], Dict.fromList [ ( "a", [ Static "a" ] ) ] )
+                    , ( [ "b" ], Dict.fromList [ ( "b", [ Static "b" ] ) ] )
+                    , ( [ "b", "c" ], Dict.fromList [ ( "c", [ Static "c" ] ) ] )
+                    , ( [ "b", "c", "d" ], Dict.fromList [ ( "d", [ Static "d" ] ) ] )
                     ]
                     |> Elm.fromText "a"
                     |> Expect.equalLists multipleFiles

--- a/tests/ElmTests.elm
+++ b/tests/ElmTests.elm
@@ -107,9 +107,9 @@ foo19BarBaz fromString parameters =
 
 prefixedFile : Elm.File
 prefixedFile =
-    { path = [ "123" ]
+    { path = [ "T123" ]
     , content =
-        """module 123 exposing (..)
+        """module T123 exposing (..)
 
 
 t456 : (String -> a) -> { p789 : a } -> List a

--- a/tests/Helper.elm
+++ b/tests/Helper.elm
@@ -1,0 +1,38 @@
+module Helper exposing (..)
+
+import Dict exposing (Dict)
+import Fuzz exposing (Fuzzer)
+import Text exposing (Text)
+
+
+singleTextModule : String -> List Text -> Dict Text.Path Text.Module
+singleTextModule key texts =
+    Dict.fromList
+        [ ( []
+          , Dict.fromList
+                [ ( key
+                  , texts
+                  )
+                ]
+          )
+        ]
+
+
+textFuzzer : Fuzzer String
+textFuzzer =
+    Fuzz.char
+        |> Fuzz.map
+            (\c ->
+                if c == ' ' || c == '{' || c == '}' then
+                    '-'
+
+                else
+                    c
+            )
+        |> nonEmptyFuzzer
+        |> Fuzz.map String.fromList
+
+
+nonEmptyFuzzer : Fuzzer a -> Fuzzer (List a)
+nonEmptyFuzzer fuzzer =
+    Fuzz.map2 (::) fuzzer (Fuzz.list fuzzer)

--- a/tests/TextTests.elm
+++ b/tests/TextTests.elm
@@ -10,9 +10,9 @@ import Test exposing (Test, describe, fuzz, fuzz2, test)
 import Text exposing (..)
 
 
-static : Test
-static =
-    describe "static text"
+tests : Test
+tests =
+    describe "Text.fromJson"
         [ fuzz2 Fuzz.string Helper.textFuzzer "works with any non empty valid string" <|
             \name text ->
                 E.object [ ( name, E.string text ) ]
@@ -28,13 +28,7 @@ static =
                     |> Text.fromJson
                     |> Expect.equal
                         (singleTextModule "foo" [])
-        ]
-
-
-parameters : Test
-parameters =
-    describe "parameters"
-        [ fuzz Helper.textFuzzer "it constructs one parameter" <|
+        , fuzz textFuzzer "it constructs one parameter" <|
             \string ->
                 E.object [ ( "", E.string ("{{" ++ string ++ "}}") ) ]
                     |> Text.fromJson
@@ -66,36 +60,32 @@ parameters =
                             , Static ", five"
                             ]
                         )
+        , test "it flattens deeply nested json properly" <|
+            \_ ->
+                E.object
+                    [ ( "a", E.string "a" )
+                    , ( "b"
+                      , E.object
+                            [ ( "b", E.string "b" )
+                            , ( "c"
+                              , E.object
+                                    [ ( "c", E.string "c" )
+                                    , ( "d"
+                                      , E.object
+                                            [ ( "d", E.string "d" ) ]
+                                      )
+                                    ]
+                              )
+                            ]
+                      )
+                    ]
+                    |> Text.fromJson
+                    |> Expect.equal
+                        (Dict.fromList
+                            [ ( [], Dict.fromList [ ( "a", [ Text.Static "a" ] ) ] )
+                            , ( [ "b" ], Dict.fromList [ ( "b", [ Text.Static "b" ] ) ] )
+                            , ( [ "b", "c" ], Dict.fromList [ ( "c", [ Text.Static "c" ] ) ] )
+                            , ( [ "b", "c", "d" ], Dict.fromList [ ( "d", [ Text.Static "d" ] ) ] )
+                            ]
+                        )
         ]
-
-
-nesting : Test
-nesting =
-    test "it flattens deeply nested json properly" <|
-        \_ ->
-            E.object
-                [ ( "a", E.string "a" )
-                , ( "b"
-                  , E.object
-                        [ ( "b", E.string "b" )
-                        , ( "c"
-                          , E.object
-                                [ ( "c", E.string "c" )
-                                , ( "d"
-                                  , E.object
-                                        [ ( "d", E.string "d" ) ]
-                                  )
-                                ]
-                          )
-                        ]
-                  )
-                ]
-                |> Text.fromJson
-                |> Expect.equal
-                    (Dict.fromList
-                        [ ( [], Dict.fromList [ ( "a", [ Text.Static "a" ] ) ] )
-                        , ( [ "b" ], Dict.fromList [ ( "b", [ Text.Static "b" ] ) ] )
-                        , ( [ "b", "c" ], Dict.fromList [ ( "c", [ Text.Static "c" ] ) ] )
-                        , ( [ "b", "c", "d" ], Dict.fromList [ ( "d", [ Text.Static "d" ] ) ] )
-                        ]
-                    )

--- a/tests/TextTests.elm
+++ b/tests/TextTests.elm
@@ -82,10 +82,10 @@ tests =
                     |> Text.fromJson
                     |> Expect.equal
                         (Dict.fromList
-                            [ ( [], Dict.fromList [ ( "a", [ Text.Static "a" ] ) ] )
-                            , ( [ "b" ], Dict.fromList [ ( "b", [ Text.Static "b" ] ) ] )
-                            , ( [ "b", "c" ], Dict.fromList [ ( "c", [ Text.Static "c" ] ) ] )
-                            , ( [ "b", "c", "d" ], Dict.fromList [ ( "d", [ Text.Static "d" ] ) ] )
+                            [ ( [], Dict.fromList [ ( "a", [ Static "a" ] ) ] )
+                            , ( [ "b" ], Dict.fromList [ ( "b", [ Static "b" ] ) ] )
+                            , ( [ "b", "c" ], Dict.fromList [ ( "c", [ Static "c" ] ) ] )
+                            , ( [ "b", "c", "d" ], Dict.fromList [ ( "d", [ Static "d" ] ) ] )
                             ]
                         )
         ]


### PR DESCRIPTION
* Break up test suite a bit
* Validate all Elm output by trying to parse it and fail the tests if it fails
* Use fuzzers to cover more cases
* Improvement: prepend module names with "T" if they start with numbers